### PR TITLE
Add sh_checker_only_diff feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: sh-checker
-        uses: luizm/action-sh-checker@master
+        uses: ./. # Use the local action, at the current version
         with:
           sh_checker_comment: true
+          sh_checker_only_diff: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,12 @@ RUN apk add --no-cache bash git jq curl checkbashisms xz \
     && chmod +x /usr/local/bin/shfmt \
     && wget "https://github.com/koalaman/shellcheck/releases/download/v${shellcheck_version}/shellcheck-v${shellcheck_version}.linux.x86_64.tar.xz"  -O- | tar xJ -C /usr/local/bin/ --strip-components=1 --wildcards '*/shellcheck' \
     && chmod +x /usr/local/bin/shellcheck \
+    && curl -L https://github.com/cli/cli/releases/download/v2.23.0/gh_2.23.0_linux_amd64.tar.gz | tar xz -C /usr/local/ --strip-components=1 \
     && apk del --no-cache .build-deps \
     && rm -rf /tmp/*
+
+# https://github.com/actions/runner-images/issues/6775#issuecomment-1410270956
+RUN git config --system --add safe.directory /github/workspace
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ jobs:
 
 ### Inputs
 
+`sh_checker_only_diff`: (optional) Only check the files that were changed in the pull request. Default is to check all files in the repo.
+
 `sh_checker_exclude`: (optional) Directory or file name that doesn't need to be checked.
 
 `sh_checker_comment`: (optional) If true, it will show the errors as commentaries in the pull requests. Default is false.
@@ -50,4 +52,4 @@ jobs:
 `sh_checker_checkbashisms_enable`: (optional) If true, run checkbashisms tool against scripts. Default is false.
 ### Secrets
 
-`GITHUB_TOKEN`: (optional) The GitHub API token used to post comments to pull requests. Not required if `sh_checker_comment` is set to false.
+`GITHUB_TOKEN`: The GitHub API token used to post comments to pull requests. Required only if `sh_checker_only_diff` or `sh_checker_comment` is set to true.

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
   sh_checker_comment:
     description: "If true, it will show the errors as commentaries in the pull requests. Default is false"
     required: false
+  sh_checker_only_diff:
+    description: "If true, run only on files changed in the PR branch. Default is false"
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"


### PR DESCRIPTION
This PR adds a `sh_checker_only_diff` feature which uses the `gh` cli to find out what files are touched by a PR (See https://cli.github.com/manual/gh_pr_diff).